### PR TITLE
fix(ci): Update workflow to count .jpg cover images from Canvas post-processing

### DIFF
--- a/.github/workflows/content-factory.yml
+++ b/.github/workflows/content-factory.yml
@@ -86,13 +86,13 @@ jobs:
         if: always()
         run: |
           ARTICLE_COUNT=$(find ./articles -name "*.txt" 2>/dev/null | wc -l)
-          IMAGE_COUNT=$(find ./articles -name "*.png" 2>/dev/null | wc -l)
+          IMAGE_COUNT=$(find ./articles -name "*.jpg" -o -name "*.png" 2>/dev/null | wc -l)
           
           echo ""
           echo "Generation Summary:"
           echo "====================================================="
           echo "Articles generated: $ARTICLE_COUNT"
-          echo "Images generated:   $IMAGE_COUNT"
+          echo "Images generated:   $IMAGE_COUNT (JPEG + PNG)"
           echo "====================================================="
           echo ""
       
@@ -114,7 +114,7 @@ jobs:
           git add articles/ 2>/dev/null || true
           
           ARTICLE_COUNT=$(find ./articles -name "*.txt" 2>/dev/null | wc -l)
-          IMAGE_COUNT=$(find ./articles -name "*.png" 2>/dev/null | wc -l)
+          IMAGE_COUNT=$(find ./articles -name "*.jpg" -o -name "*.png" 2>/dev/null | wc -l)
           
           git commit -m "Dzen: ${{ inputs.count }} articles (${{ inputs.channel }}) - $IMAGE_COUNT images (run ${{ github.run_id }})" || echo "No changes"
           git push origin HEAD:main || echo "Push failed"


### PR DESCRIPTION
## 🎯 What

Update GitHub Actions workflow to properly count JPEG cover images from Canvas post-processing (v4.0.2)

## 🤔 Why

- PR #37 changed image output from PNG to JPEG (Canvas post-processing with metadata removal)
- GitHub Actions workflow was still looking for `.png` files only
- This caused image counting to fail in the workflow
- Updated to search for both `.jpg` AND `.png` for backward compatibility

## 📝 Changes

### File: `.github/workflows/content-factory.yml`

**Change 1** (Line 62, "Count results" step):
```bash
# BEFORE:
IMAGE_COUNT=$(find ./articles -name "*.png" 2>/dev/null | wc -l)

# AFTER:
IMAGE_COUNT=$(find ./articles -name "*.jpg" -o -name "*.png" 2>/dev/null | wc -l)
```

**Change 2** (Line 85, "Commit and push" step):
```bash
# BEFORE:
IMAGE_COUNT=$(find ./articles -name "*.png" 2>/dev/null | wc -l)

# AFTER:
IMAGE_COUNT=$(find ./articles -name "*.jpg" -o -name "*.png" 2>/dev/null | wc -l)
```

## ✅ Testing

1. ✅ Syntax validated
2. ✅ Backward compatible (supports both .jpg and .png)
3. ✅ Ready for manual workflow run

## 🚀 Next Steps

After merge:
1. Run workflow manually: `Actions → Run workflow → count=1, images=true`
2. Should complete successfully with proper image count
3. Artifacts should show both .txt and .jpg files

## 📋 Context

This is part of v4.0.2 Image Pipeline completion:
- ✅ PR #37: Code implementation (Canvas post-processing)
- ✅ PR #38: Documentation (README update)
- 🔧 THIS PR: GitHub Actions workflow fix

Fixes #30 (Image Generation Pipeline)