### PR TITLE
chore: simplify RSS feed workflow - use workflow_dispatch only

### DIFF
--- a/.github/workflows/generate-feed.yml
+++ b/.github/workflows/generate-feed.yml
@@ -1,18 +1,16 @@
 name: Generate RSS Feed
 
 on:
-  push:
-    branches: [ main, master ]
-    # Теперь правильно отслеживаем ВСЕ изменения в articles (КРОМЕ published и техфайлов)
-    paths:
-      - 'articles/**'
-      - '!articles/published/**'
-      - '!articles/REPORT.md'
-      - '!articles/manifest.json'
-  schedule:
-    # Запускать каждый час
-    - cron: '0 * * * *'
-  workflow_dispatch: # Ручной запуск
+  workflow_dispatch: # Ручной запуск через GitHub UI
+    inputs:
+      mode:
+        description: 'Generation mode (full or incremental)'
+        required: true
+        default: 'incremental'
+        type: choice
+        options:
+          - full
+          - incremental
 
 jobs:
   generate-feed:
@@ -47,29 +45,20 @@ jobs:
 
     - name: Set environment variables
       run: |
-        echo "BASE_URL=https://${{ github.repository_owner }}.github.io/dzen" >> $GITHUB_ENV
-        echo "SITE_URL=https://${{ github.repository_owner }}.github.io/dzen" >> $GITHUB_ENV
-        echo "VERCEL_URL=dzen-livid.vercel.app" >> $GITHUB_ENV
         echo "GITHUB_REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
 
     - name: Generate RSS feed
-      run: node scripts/generate-feed.js
-
-    - name: Create public directory and copy feed
-      run: |
-        mkdir -p public
-        cp feed.xml public/ || echo "feed.xml not found"
-        cp index.html public/ || echo "index.html not found"
+      run: node scripts/generate-feed.js ${{ github.event.inputs.mode }}
 
     - name: Commit and push if changed
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        git add feed.xml public/ articles/published/
+        git add public/feed.xml
         if git diff --staged --quiet; then
           echo "No changes to commit"
         else
-          git commit -m "Auto-generate RSS feed and move articles to published [skip ci]"
+          git commit -m "chore(rss): update feed [${{ github.event.inputs.mode }} mode]"
           git push
         fi
       continue-on-error: true


### PR DESCRIPTION
## Summary

Simplify the RSS feed workflow by removing automatic triggers and switching to manual `workflow_dispatch` mode with input selection.

## Changes

- **Removed**: Automatic push triggers and scheduled `cron` jobs
- **Removed**: Unnecessary environment variable setup (`BASE_URL`, `SITE_URL`, `VERCEL_URL`)
- **Removed**: Auto-copy to `public/` directory logic
- **Removed**: Auto-moving articles to `published/` folder
- **Added**: Manual `workflow_dispatch` with mode input (`full` or `incremental`)
- **Simplified**: RSS feed generation directly to `public/feed.xml`

## Mode Description

- **`incremental`** (default): Process only new articles in `articles/women-35-60/` folder
- **`full`**: Process all articles from all folders in `articles/`

## How to Use

1. Go to GitHub Actions → "Generate RSS Feed" workflow
2. Click "Run workflow"
3. Select mode: `full` or `incremental`
4. Click "Run workflow"

## Technical Details

- Uses existing `generate-feed.js` script which properly:
  - Targets Yandex Zen channel: `https://dzen.ru/potemki`
  - Generates GitHub Raw URLs for images
  - Creates proper RSS 2.0 with `content:encoded` CDATA
  - Validates frontmatter (title, date required)
  - Checks image existence before including
